### PR TITLE
Removed the Offending check for None with grard to review load cmds

### DIFF
--- a/dpa_check.py
+++ b/dpa_check.py
@@ -302,8 +302,7 @@ def make_week_predict(opt, tstart, tstop, bs_cmds, tlm, db):
 
     # Delete non-load cmds that are within the backstop time span
     # => Keep if timeline_id is not None or date < bs_cmds[0]['time']
-    db_cmds = [x for x in db_cmds if (x['timeline_id'] is not None or
-                                      x['time'] < bs_cmds[0]['time'])]
+    db_cmds = [x for x in db_cmds if x['time'] < bs_cmds[0]['time'] ]
 
     logger.info('Got %d cmds from database between %s and %s' %
                   (len(db_cmds), cmds_datestart, cmds_datestop))


### PR DESCRIPTION
Removed the Offending check for None with regard to review load cmds.  Tested 
	FEB2017/
	FEB2717/
	MAR0617/
	MAR1317/

loads and the prediction plots looked identical.