### PR TITLE
Update dpa_check to work with updated version of acis_thermal_check

### DIFF
--- a/dpa_check/__init__.py
+++ b/dpa_check/__init__.py
@@ -1,1 +1,4 @@
 __version__ = "2.1.0"
+
+from .dpa_check import \
+    calc_model

--- a/dpa_check/__init__.py
+++ b/dpa_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 from .dpa_check import \
     calc_model

--- a/dpa_check/dpa_check.py
+++ b/dpa_check/dpa_check.py
@@ -58,7 +58,7 @@ def main():
                                  VALIDATION_LIMITS, HIST_LIMIT,
                                  calc_model, args)
     try:
-        dpa_check.driver()
+        dpa_check.run()
     except Exception as msg:
         if args.traceback:
             raise

--- a/dpa_check/dpa_check.py
+++ b/dpa_check/dpa_check.py
@@ -36,7 +36,8 @@ VALIDATION_LIMITS = {'1DPAMZT': [(1, 2.0), (50, 1.0), (99, 2.0)],
 
 HIST_LIMIT = [20.]
 
-def calc_model(model_spec, states, start, stop, T_dpa=None, T_dpa_times=None):
+def calc_model(model_spec, states, start, stop, T_dpa=None, T_dpa_times=None,
+               dh_heater=None, dh_heater_times=None):
     model = xija.ThermalModel('dpa', start=start, stop=stop,
                               model_spec=model_spec)
     times = np.array([states['tstart'], states['tstop']])

--- a/dpa_check/dpa_check.py
+++ b/dpa_check/dpa_check.py
@@ -28,7 +28,6 @@ import os
 
 model_path = os.path.abspath(os.path.dirname(__file__))
 
-MSID = {"dpa": '1DPAMZT'}
 VALIDATION_LIMITS = {'1DPAMZT': [(1, 2.0), (50, 1.0), (99, 2.0)],
                      'PITCH': [(1, 3.0), (99, 3.0)],
                      'TSCPOS': [(1, 2.5), (99, 2.5)]
@@ -54,9 +53,8 @@ def calc_model(model_spec, states, start, stop, T_dpa=None, T_dpa_times=None,
 
 def main():
     args = get_options("dpa", model_path)
-    dpa_check = ACISThermalCheck("1dpamzt", "dpa", MSID,
-                                 VALIDATION_LIMITS, HIST_LIMIT,
-                                 calc_model, args)
+    dpa_check = ACISThermalCheck("1dpamzt", "dpa", VALIDATION_LIMITS,
+                                 HIST_LIMIT, calc_model, args)
     try:
         dpa_check.run()
     except Exception as msg:

--- a/dpa_check/dpa_check.py
+++ b/dpa_check/dpa_check.py
@@ -23,34 +23,12 @@ import sys
 from acis_thermal_check import \
     ACISThermalCheck, \
     calc_off_nom_rolls, \
-    get_options, \
-    make_state_builder, \
-    get_acis_limits
+    get_options
 import os
 
 model_path = os.path.abspath(os.path.dirname(__file__))
 
-yellow_hi, red_hi = get_acis_limits("1dpamzt")
-
 MSID = {"dpa": '1DPAMZT'}
-# This is the Yellow High IPCL limit.
-# 05/2014 - changed from 35.0 to 37.5
-YELLOW = {"dpa": yellow_hi}
-# This is the difference between the Yellow High IPCL limit and 
-# the Planning Limit. So the Planning Limit is YELLOW - MARGIN
-#
-# 12/5/13 - This value was changed from 2.5 to 2.0 to reflect the new 
-# 1DPAMZT planning limit of 33 degrees C
-# 05/19/14 this is changed from 2.0, to 3.0.  2 degress for the normal
-#          padding for model error and an additional degree because
-#          the total change is being done in increments. We will back
-#          this off from 3 degrees to two after a few months trial 
-#          testing.  So for now the planning limit will be 34.5 deg. C.
-# 09/19/14 - Set MARGIN to 2.0 so that the Planning Limit is now 
-#            35.5 deg. C
-MARGIN = {"dpa": 2.0}
-# 12/5/13 - Likewise the 1DPAMZT validation limits were reduced to 2.0 
-#           from 2.5 for the 1% and 99% quantiles
 VALIDATION_LIMITS = {'1DPAMZT': [(1, 2.0), (50, 1.0), (99, 2.0)],
                      'PITCH': [(1, 3.0), (99, 3.0)],
                      'TSCPOS': [(1, 2.5), (99, 2.5)]
@@ -75,12 +53,11 @@ def calc_model(model_spec, states, start, stop, T_dpa=None, T_dpa_times=None):
 
 def main():
     args = get_options("dpa", model_path)
-    state_builder = make_state_builder(args.state_builder, args)
-    dpa_check = ACISThermalCheck("1dpamzt", "dpa", MSID, YELLOW,
-                                 MARGIN, VALIDATION_LIMITS,
-                                 HIST_LIMIT, calc_model)
+    dpa_check = ACISThermalCheck("1dpamzt", "dpa", MSID,
+                                 VALIDATION_LIMITS, HIST_LIMIT,
+                                 calc_model, args)
     try:
-        dpa_check.driver(args, state_builder)
+        dpa_check.driver()
     except Exception as msg:
         if args.traceback:
             raise

--- a/dpa_check/tests/conftest.py
+++ b/dpa_check/tests/conftest.py
@@ -1,9 +1,2 @@
-import pytest
-
-def pytest_addoption(parser):
-    parser.addoption("--answer_store",
-                     help="Generate new answers, but don't test. Argument is the directory to store the answers to.")
-
-@pytest.fixture()
-def generate_answers(request):
-    return request.config.getoption('--answer_store')
+from acis_thermal_check.regression_testing import \
+    pytest_addoption, answer_store

--- a/dpa_check/tests/test_dpa.py
+++ b/dpa_check/tests/test_dpa.py
@@ -1,10 +1,12 @@
 from ..dpa_check import VALIDATION_LIMITS, \
     HIST_LIMIT, calc_model, model_path
 from acis_thermal_check.regression_testing import \
-    run_test_arrays
+    RegressionTester
+
+dpa_rt = RegressionTester("1dpamzt", "dpa", model_path, VALIDATION_LIMITS,
+                          HIST_LIMIT, calc_model)
 
 def test_dpa_loads(answer_store):
-    run_test_arrays("1dpamzt", "dpa", model_path,
-                    [VALIDATION_LIMITS, HIST_LIMIT, calc_model],
-                    answer_store)
+    dpa_rt.run_test_arrays([VALIDATION_LIMITS, HIST_LIMIT, calc_model],
+                           answer_store)
 

--- a/dpa_check/tests/test_dpa.py
+++ b/dpa_check/tests/test_dpa.py
@@ -1,12 +1,10 @@
-from ..dpa_check import dpa_check, model_path
+from ..dpa_check import VALIDATION_LIMITS, \
+    HIST_LIMIT, calc_model, model_path
 from acis_thermal_check.regression_testing import \
-    load_test_template
-import os
+    run_test_arrays
 
-default_model_spec = os.path.join(model_path, "dpa_model_spec.json")
+def test_dpa_loads(answer_store):
+    run_test_arrays("1dpamzt", "dpa", model_path,
+                    [VALIDATION_LIMITS, HIST_LIMIT, calc_model],
+                    answer_store)
 
-def test_dpa_may3016(answer_store):
-    run_start = "2016:122:12:00:00.000"
-    load_week = "MAY3016"
-    load_test_template("1dpamzt", "dpa", answer_store, run_start,
-                       load_week, default_model_spec, dpa_check)

--- a/dpa_check/tests/test_dpa.py
+++ b/dpa_check/tests/test_dpa.py
@@ -7,6 +7,5 @@ dpa_rt = RegressionTester("1dpamzt", "dpa", model_path, VALIDATION_LIMITS,
                           HIST_LIMIT, calc_model)
 
 def test_dpa_loads(answer_store):
-    dpa_rt.run_test_arrays([VALIDATION_LIMITS, HIST_LIMIT, calc_model],
-                           answer_store)
+    dpa_rt.run_test_arrays(answer_store)
 


### PR DESCRIPTION
This PR provides the updates to `dpa_check` to make it work with the new version of `acis_thermal_check` (PR acisops/acis_thermal_check#14). The result is a simplified code base and improved support for regression testing.

Highlights:

1. The yellow and margin limits are obtained using the `get_acis_limits` function internally in `ACISThermalCheck` and no longer need to be kept in this script.
2. It is no longer necessary for the script to construct the `StateBuilder` object as this now happens internally in `ACISThermalCheck`.
3. An updated regression test has been added which tests model outputs against validated answers for a number of loads.