### PR TITLE
Updated dpa_check.py to account for pseudo node initialization, and u…

### DIFF
--- a/dpa_check/__init__.py
+++ b/dpa_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 
 from .dpa_check import \
     calc_model

--- a/dpa_check/dpa_check.py
+++ b/dpa_check/dpa_check.py
@@ -43,6 +43,23 @@ def calc_model(model_spec, states, start, stop, T_dpa=None, T_dpa_times=None,
     model.comp['sim_z'].set_data(states['simpos'], times)
     model.comp['eclipse'].set_data(False)
     model.comp['1dpamzt'].set_data(T_dpa, T_dpa_times)
+
+    # Update to initialize the dpa0 pseudo-node. If 1dpamzt
+    # has an initial value (T_dpa) - which it does at
+    # prediction time (gets it from state0), then T_dpa0 
+    # is set to that.  If we are running the validation,
+    # T_dpa is set to None so we use the dvals in model.comp
+    #
+    # NOTE: If you change the name of the dpa0 pseudo node you
+    #       have to edit the new name into the if statement
+    #       below.
+    if 'dpa0' in model.comp:
+        if T_dpa is None:
+            T_dpa0 = model.comp["1dpamzt"].dvals
+        else:
+            T_dpa0 = T_dpa
+        model.comp['dpa0'].set_data(T_dpa0, T_dpa_times)
+
     model.comp['roll'].set_data(calc_off_nom_rolls(states), times)
     for name in ('ccd_count', 'fep_count', 'vid_board', 'clocking', 'pitch'):
         model.comp[name].set_data(states[name], times)

--- a/dpa_check/dpa_model_spec.json
+++ b/dpa_check/dpa_model_spec.json
@@ -55,6 +55,27 @@
             "name": "1dpamzt"
         }, 
         {
+            "class_name": "Node", 
+            "init_args": [
+                "dpa0"
+            ], 
+            "init_kwargs": {
+                "sigma": 100000.0
+            }, 
+            "name": "dpa0"
+        }, 
+        {
+            "class_name": "Coupling", 
+            "init_args": [
+                "1dpamzt", 
+                "dpa0"
+            ], 
+            "init_kwargs": {
+                "tau": 30.0
+            }, 
+            "name": "coupling__1dpamzt__dpa0"
+        }, 
+        {
             "class_name": "SimZ", 
             "init_args": [], 
             "init_kwargs": {}, 
@@ -111,9 +132,9 @@
             "name": "clocking"
         }, 
         {
-            "class_name": "SolarHeatHrc", 
+            "class_name": "SolarHeatHrcOpts", 
             "init_args": [
-                "1dpamzt"
+                "dpa0"
             ], 
             "init_kwargs": {
                 "P_pitches": [
@@ -126,6 +147,8 @@
                     130, 
                     140, 
                     150, 
+                    160, 
+                    170, 
                     180
                 ], 
                 "Ps": [
@@ -138,20 +161,22 @@
                     1.0, 
                     0.9, 
                     0.8, 
+                    0.8, 
+                    0.8, 
                     0.7
                 ], 
                 "eclipse_comp": "eclipse", 
-                "epoch": "2017:322", 
+                "epoch": "2018:003", 
                 "pitch_comp": "pitch", 
                 "simz_comp": "sim_z", 
                 "var_func": "linear"
             }, 
-            "name": "solarheat__1dpamzt"
+            "name": "solarheat__dpa0"
         }, 
         {
             "class_name": "SolarHeatOffNomRoll", 
             "init_args": [
-                "1dpamzt"
+                "dpa0"
             ], 
             "init_kwargs": {
                 "P_minus_y": 0.0, 
@@ -160,20 +185,20 @@
                 "pitch_comp": "pitch", 
                 "roll_comp": "roll"
             }, 
-            "name": "solarheat_off_nom_roll__1dpamzt"
+            "name": "solarheat_off_nom_roll__dpa0"
         }, 
         {
             "class_name": "HeatSinkRef", 
             "init_args": [
-                "1dpamzt"
+                "dpa0"
             ], 
             "init_kwargs": {}, 
-            "name": "heatsink__1dpamzt"
+            "name": "heatsink__dpa0"
         }, 
         {
             "class_name": "AcisDpaStatePower", 
             "init_args": [
-                "1dpamzt"
+                "dpa0"
             ], 
             "init_kwargs": {
                 "ccd_count": "ccd_count", 
@@ -186,11 +211,10 @@
                     "3xx0", 
                     "3xx1", 
                     "4xxx", 
-                    "55x0", 
-                    "5xxx", 
-                    "66x0", 
-                    "6611", 
-                    "6xxx"
+                    "5xx0", 
+                    "5xx1", 
+                    "6xx0", 
+                    "6xx1"
                 ], 
                 "vid_board": "vid_board"
             }, 
@@ -199,23 +223,26 @@
         {
             "class_name": "PropHeater", 
             "init_args": [
-                "1dpamzt"
+                "dpa0"
             ], 
             "init_kwargs": {}, 
-            "name": "prop_heat__1dpamzt"
+            "name": "prop_heat__dpa0"
         }
     ], 
-    "datestart": "2017:272:12:03:36.816", 
-    "datestop": "2018:007:11:50:08.816", 
+    "datestart": "2017:186:12:01:44.816", 
+    "datestop": "2018:186:11:54:24.816", 
     "dt": 328.0, 
     "gui_config": {
-        "filename": "/home/gregg/xija/JAN_08_Tweaked_Secular_3xx0_55x0_eq_52_6611_eq_83.16.json", 
+        "filename": "/home/gregg/THERMAL-MODELS/dpa_check/dpa_check/July_9A_Step_6.json", 
         "plot_names": [
             "1dpamzt data__time", 
+            "1dpamzt resid__time", 
             "fep_count data__time", 
-            "1dpamzt resid__time"
+            "solarheat__dpa0 solar_heat__pitch"
         ], 
-        "set_data_vals": {}, 
+        "set_data_vals": {
+            "dpa0": 20
+        }, 
         "size": [
             1703, 
             1028
@@ -235,294 +262,354 @@
             "val": 10.0
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "coupling__1dpamzt__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_45", 
+            "full_name": "coupling__1dpamzt__dpa0__tau", 
+            "max": 200.0, 
+            "min": 0.01, 
+            "name": "tau", 
+            "val": 1.3125
+        }, 
+        {
+            "comp_name": "solarheat__dpa0", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat__dpa0__P_45", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_45", 
-            "val": 0.327587768280721
+            "val": 0.3093064500639312
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_60", 
+            "full_name": "solarheat__dpa0__P_60", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_60", 
-            "val": 0.50691536564681283
+            "val": 0.497382427594075
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_90", 
+            "full_name": "solarheat__dpa0__P_90", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_90", 
-            "val": 0.65278948587181806
+            "val": 0.6418695562675141
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_105", 
+            "full_name": "solarheat__dpa0__P_105", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_105", 
-            "val": 1.0458399832631315
+            "val": 1.048
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_115", 
+            "full_name": "solarheat__dpa0__P_115", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_115", 
-            "val": 1.4577180298448442
+            "val": 1.36
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_125", 
+            "full_name": "solarheat__dpa0__P_125", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_125", 
-            "val": 1.6220613701704625
+            "val": 1.6313261305602202
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_130", 
+            "full_name": "solarheat__dpa0__P_130", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_130", 
-            "val": 1.76337047173646
+            "val": 1.7705657321693469
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_140", 
+            "full_name": "solarheat__dpa0__P_140", 
             "max": 2.114, 
             "min": 0.0, 
             "name": "P_140", 
-            "val": 1.9519176394735367
+            "val": 1.9437944635650097
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_150", 
-            "max": 2.0136579807938038, 
+            "full_name": "solarheat__dpa0__P_150", 
+            "max": 3.015143558247852, 
             "min": 0.0, 
             "name": "P_150", 
-            "val": 2.0079476896314135
+            "val": 2.026413485276535
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__P_180", 
+            "full_name": "solarheat__dpa0__P_160", 
+            "max": 3.015143558247852, 
+            "min": 0.0, 
+            "name": "P_160", 
+            "val": 2.017962598036436
+        }, 
+        {
+            "comp_name": "solarheat__dpa0", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat__dpa0__P_170", 
+            "max": 3.015143558247852, 
+            "min": 0.0, 
+            "name": "P_170", 
+            "val": 1.95
+        }, 
+        {
+            "comp_name": "solarheat__dpa0", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat__dpa0__P_180", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "P_180", 
-            "val": 1.9064118239156627
+            "val": 1.8363035366791458
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_45", 
+            "full_name": "solarheat__dpa0__dP_45", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_45", 
-            "val": -0.20468427918938972
+            "val": 0.0012286720429483628
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_60", 
+            "full_name": "solarheat__dpa0__dP_60", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_60", 
-            "val": 0.02932516470207419
+            "val": 0.003990131413589554
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_90", 
+            "full_name": "solarheat__dpa0__dP_90", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_90", 
-            "val": 0.09882807215911346
+            "val": 0.0014844992719995837
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_105", 
+            "full_name": "solarheat__dpa0__dP_105", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_105", 
-            "val": 0.0351562639363239
+            "val": 0.23714353688405265
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_115", 
+            "full_name": "solarheat__dpa0__dP_115", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_115", 
-            "val": 0.058844389546675466
+            "val": 0.3032127355060925
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_125", 
+            "full_name": "solarheat__dpa0__dP_125", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_125", 
-            "val": 0.0351562639363239
+            "val": 0.1834075109856065
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_130", 
+            "full_name": "solarheat__dpa0__dP_130", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_130", 
-            "val": 0.20299762838972854
+            "val": 0.24743146426576731
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_140", 
+            "full_name": "solarheat__dpa0__dP_140", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_140", 
-            "val": 0.014620612573331105
+            "val": 0.25
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_150", 
+            "full_name": "solarheat__dpa0__dP_150", 
             "max": 1.0, 
-            "min": -1.0, 
+            "min": 0.0, 
             "name": "dP_150", 
-            "val": 0.36556641827690867
+            "val": 0.20494192038409578
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__dP_180", 
+            "full_name": "solarheat__dpa0__dP_160", 
             "max": 1.0, 
-            "min": -1.0, 
-            "name": "dP_180", 
-            "val": 0.05909712404953001
+            "min": 0.0, 
+            "name": "dP_160", 
+            "val": 0.16593265270015206
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__tau", 
+            "full_name": "solarheat__dpa0__dP_170", 
+            "max": 1.0, 
+            "min": 0.0, 
+            "name": "dP_170", 
+            "val": 0.2147
+        }, 
+        {
+            "comp_name": "solarheat__dpa0", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat__dpa0__dP_180", 
+            "max": 1.0, 
+            "min": 0.0, 
+            "name": "dP_180", 
+            "val": 0.3012993938342542
+        }, 
+        {
+            "comp_name": "solarheat__dpa0", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat__dpa0__tau", 
             "max": 3000.0, 
             "min": 1000.0, 
             "name": "tau", 
             "val": 1269.8035520969406
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__ampl", 
+            "full_name": "solarheat__dpa0__ampl", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "ampl", 
             "val": 0.046427256777960654
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__bias", 
+            "full_name": "solarheat__dpa0__bias", 
             "max": 1.0, 
             "min": -1.0, 
             "name": "bias", 
             "val": -0.022005431182122764
         }, 
         {
-            "comp_name": "solarheat__1dpamzt", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat__1dpamzt__hrc_bias", 
+            "full_name": "solarheat__dpa0__hrci_bias", 
             "max": 1.0, 
             "min": -1.0, 
-            "name": "hrc_bias", 
-            "val": -0.08850072080437976
+            "name": "hrci_bias", 
+            "val": -0.031240811843720816
         }, 
         {
-            "comp_name": "solarheat_off_nom_roll", 
+            "comp_name": "solarheat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat_off_nom_roll__P_plus_y", 
+            "full_name": "solarheat__dpa0__hrcs_bias", 
+            "max": 1.0, 
+            "min": -1.0, 
+            "name": "hrcs_bias", 
+            "val": -0.08228808708920946
+        }, 
+        {
+            "comp_name": "solarheat_off_nom_roll__dpa0", 
+            "fmt": "{:.4g}", 
+            "frozen": true, 
+            "full_name": "solarheat_off_nom_roll__dpa0__P_plus_y", 
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_plus_y", 
-            "val": 1.3
+            "val": 1.2991132666444623
         }, 
         {
-            "comp_name": "solarheat_off_nom_roll", 
+            "comp_name": "solarheat_off_nom_roll__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "solarheat_off_nom_roll__P_minus_y", 
+            "full_name": "solarheat_off_nom_roll__dpa0__P_minus_y", 
             "max": 5.0, 
             "min": -5.0, 
             "name": "P_minus_y", 
-            "val": 0.3
+            "val": 0.5635394863960609
         }, 
         {
-            "comp_name": "heatsink__1dpamzt", 
+            "comp_name": "heatsink__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "heatsink__1dpamzt__P", 
+            "full_name": "heatsink__dpa0__P", 
             "max": 10.0, 
             "min": -10.0, 
             "name": "P", 
-            "val": -2.377751557364746
+            "val": -2.470068448383086
         }, 
         {
-            "comp_name": "heatsink__1dpamzt", 
+            "comp_name": "heatsink__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "heatsink__1dpamzt__tau", 
+            "full_name": "heatsink__dpa0__tau", 
             "max": 200.0, 
             "min": 2.0, 
             "name": "tau", 
-            "val": 24.749591590528688
+            "val": 24.343187767342535
         }, 
         {
-            "comp_name": "heatsink__1dpamzt", 
+            "comp_name": "heatsink__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "heatsink__1dpamzt__T_ref", 
+            "full_name": "heatsink__dpa0__T_ref", 
             "max": 100, 
             "min": -100, 
             "name": "T_ref", 
-            "val": 19.36156808627122
+            "val": 21.10861225721419
         }, 
         {
             "comp_name": "dpa_power", 
@@ -532,7 +619,7 @@
             "max": 60, 
             "min": 10, 
             "name": "pow_0xxx", 
-            "val": 12.013499335555018
+            "val": 12.269192065321814
         }, 
         {
             "comp_name": "dpa_power", 
@@ -542,7 +629,7 @@
             "max": 60, 
             "min": 15, 
             "name": "pow_1xxx", 
-            "val": 24.886931775802445
+            "val": 28.14402341828865
         }, 
         {
             "comp_name": "dpa_power", 
@@ -552,7 +639,7 @@
             "max": 80, 
             "min": 20, 
             "name": "pow_2xxx", 
-            "val": 33.79737205888341
+            "val": 38.36118855027189
         }, 
         {
             "comp_name": "dpa_power", 
@@ -562,7 +649,7 @@
             "max": 100, 
             "min": 20, 
             "name": "pow_3xx0", 
-            "val": 48.87
+            "val": 40.291991910003745
         }, 
         {
             "comp_name": "dpa_power", 
@@ -572,7 +659,7 @@
             "max": 100, 
             "min": 20, 
             "name": "pow_3xx1", 
-            "val": 48.874228334449356
+            "val": 49.65675154320987
         }, 
         {
             "comp_name": "dpa_power", 
@@ -582,57 +669,47 @@
             "max": 120, 
             "min": 20, 
             "name": "pow_4xxx", 
-            "val": 59.473684210526315
+            "val": 59.39393939393939
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_55x0", 
+            "full_name": "dpa_power__pow_5xx0", 
             "max": 120, 
             "min": 20, 
-            "name": "pow_55x0", 
-            "val": 52.0
+            "name": "pow_5xx0", 
+            "val": 55.88509680292602
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_5xxx", 
+            "full_name": "dpa_power__pow_5xx1", 
             "max": 120, 
             "min": 20, 
-            "name": "pow_5xxx", 
-            "val": 65.84274749755124
+            "name": "pow_5xx1", 
+            "val": 68.48484848484848
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_66x0", 
+            "full_name": "dpa_power__pow_6xx0", 
             "max": 140, 
             "min": 20, 
-            "name": "pow_66x0", 
-            "val": 61.73163047104799
+            "name": "pow_6xx0", 
+            "val": 62.08753913831623
         }, 
         {
             "comp_name": "dpa_power", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "dpa_power__pow_6611", 
+            "full_name": "dpa_power__pow_6xx1", 
             "max": 140, 
             "min": 20, 
-            "name": "pow_6611", 
-            "val": 83.15789473684211
-        }, 
-        {
-            "comp_name": "dpa_power", 
-            "fmt": "{:.4g}", 
-            "frozen": true, 
-            "full_name": "dpa_power__pow_6xxx", 
-            "max": 140, 
-            "min": 20, 
-            "name": "pow_6xxx", 
-            "val": 78.21954023381123
+            "name": "pow_6xx1", 
+            "val": 78.56392503521457
         }, 
         {
             "comp_name": "dpa_power", 
@@ -642,7 +719,7 @@
             "max": 2.0, 
             "min": 0.0, 
             "name": "mult", 
-            "val": 1.8152421598951174
+            "val": 1.8317188058387148
         }, 
         {
             "comp_name": "dpa_power", 
@@ -652,27 +729,27 @@
             "max": 100, 
             "min": 0.0, 
             "name": "bias", 
-            "val": 0.05231746528297662
+            "val": 0.476387415267527
         }, 
         {
-            "comp_name": "prop_heat__1dpamzt", 
+            "comp_name": "prop_heat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "prop_heat__1dpamzt__k", 
+            "full_name": "prop_heat__dpa0__k", 
             "max": 2.0, 
             "min": 0.0, 
             "name": "k", 
-            "val": 0.18302534088641037
+            "val": 0.26945112213641037
         }, 
         {
-            "comp_name": "prop_heat__1dpamzt", 
+            "comp_name": "prop_heat__dpa0", 
             "fmt": "{:.4g}", 
             "frozen": true, 
-            "full_name": "prop_heat__1dpamzt__T_set", 
+            "full_name": "prop_heat__dpa0__T_set", 
             "max": 100.0, 
             "min": -50.0, 
             "name": "T_set", 
-            "val": 14.01383767718995
+            "val": 12.951093536564954
         }
     ], 
     "tlm_code": null


### PR DESCRIPTION
Updated dpa_check.py to account for pseudo node initialization, and updated the re-cal'd 1DPAMZT json file to fix a 5xx0 and 5xx1 name bug

Both the JSON file was fixed to take care of the 5xx0 and 5xx1 name: bug and the dpa_check.py program was modified such that the dpa0 node is properly initialized.

Here is the old JSON file validation plot for JUL1618:

![1dpamzt_valid](https://user-images.githubusercontent.com/1727498/42840839-1e3205a6-89d6-11e8-8060-98fba3b55325.png)

...And here is the new JSON file validation plot for JUL1618:

![1dpamzt_valid](https://user-images.githubusercontent.com/1727498/42840852-2fea30f2-89d6-11e8-8148-72c628433df7.png)
