### PR TITLE
Add customizations to support checking +12 degC/0 FEPs violations, other minor updates

### DIFF
--- a/dpa_check/dpa_check.py
+++ b/dpa_check/dpa_check.py
@@ -69,8 +69,8 @@ class DPACheck(ACISThermalCheck):
 
     def custom_validation_plots(self, plots):
         plots[0]['lines']['ax'].axhline(self.zero_feps_limit, linestyle='--',
-                                        color='dodgerblue', zorder=-8, 
-                                        linewidth=2)
+                                        color='dodgerblue', zorder=-8,
+                                        linewidth=2, label="Zero FEPs")
 
     def _calc_model_supp(self, model, state_times, states, ephem, state0):
         """

--- a/dpa_check/dpa_check.py
+++ b/dpa_check/dpa_check.py
@@ -36,13 +36,24 @@ class DPACheck(ACISThermalCheck):
                                        hist_limit)
 
     def custom_prediction_plots(self, plots):
+        """
+        Customization of prediction plots.
+
+        Parameters
+        ----------
+        plots : dict of dicts
+            Contains the hooks to the plot figures, axes, and filenames
+            and can be used to customize plots before they are written,
+            e.g. add limit lines, etc.
+        """
         plots[self.name]['ax'].axhline(self.zero_feps_limit, linestyle='--',
                                        color='dodgerblue', label="Zero FEPs",
                                        linewidth=2.0)
 
     def custom_prediction_viols(self, times, temp, viols, load_start):
         """
-        Custom handling of limit violations. 
+        Custom handling of limit violations. This is for checking the
+        +12 degC violation if all FEPs are off. 
 
         Parameters
         ----------
@@ -68,6 +79,16 @@ class DPACheck(ACISThermalCheck):
                               "values": zf_viols}
 
     def custom_validation_plots(self, plots):
+        """
+        Customization of validation plots.
+
+        Parameters
+        ----------
+        plots : dict of dicts
+            Contains the hooks to the plot figures, axes, and filenames
+            and can be used to customize plots before they are written,
+            e.g. add limit lines, etc.
+        """
         plots[0]['lines']['ax'].axhline(self.zero_feps_limit, linestyle='--',
                                         color='dodgerblue', zorder=-8,
                                         linewidth=2, label="Zero FEPs")

--- a/dpa_check/dpa_check.py
+++ b/dpa_check/dpa_check.py
@@ -37,7 +37,8 @@ class DPACheck(ACISThermalCheck):
 
     def custom_prediction_plots(self, plots):
         plots[self.name]['ax'].axhline(self.zero_feps_limit, linestyle='--',
-                                       color='dodgerblue', linewidth=2.0)
+                                       color='dodgerblue', label="Zero FEPs",
+                                       linewidth=2.0)
 
     def custom_prediction_viols(self, times, temp, viols, load_start):
         """

--- a/dpa_check/dpa_check.py
+++ b/dpa_check/dpa_check.py
@@ -35,6 +35,42 @@ class DPACheck(ACISThermalCheck):
         super(DPACheck, self).__init__("1dpamzt", "dpa", valid_limits,
                                        hist_limit)
 
+    def custom_prediction_plots(self, plots):
+        plots[self.name]['ax'].axhline(self.zero_feps_limit, linestyle='--',
+                                       color='dodgerblue', linewidth=2.0)
+
+    def custom_prediction_viols(self, times, temp, viols, load_start):
+        """
+        Custom handling of limit violations. 
+
+        Parameters
+        ----------
+        times : NumPy array
+            The times for the predicted temperatures
+        temp : NumPy array
+            The predicted temperatures
+        viols : dict
+            Dictionary of violations information to add to
+        load_start : float
+            The start time of the load, used so that we only report
+            violations for times later than this time for the model
+            run.
+        """
+        # Only check this violation when all FEPs are off
+        mask = self.predict_model.comp['fep_count'].dvals == 0
+        zf_viols = self._make_prediction_viols(times, temp, load_start,
+                                               self.zero_feps_limit,
+                                               "zero-feps", "min",
+                                               mask=mask)
+        viols["zero_feps"] = {"name": f"Zero FEPs ({self.zero_feps_limit} C)",
+                              "type": "Min",
+                              "values": zf_viols}
+
+    def custom_validation_plots(self, plots):
+        plots[0]['lines']['ax'].axhline(self.zero_feps_limit, linestyle='--',
+                                        color='dodgerblue', zorder=-8, 
+                                        linewidth=2)
+
     def _calc_model_supp(self, model, state_times, states, ephem, state0):
         """
         Update to initialize the dpa0 pseudo-node. If 1dpamzt

--- a/dpa_check/tests/answers/JUL3018A_viol.json
+++ b/dpa_check/tests/answers/JUL3018A_viol.json
@@ -18,5 +18,10 @@
     "limits": {
         "yellow_hi_limit": 37.2,
         "plan_hi_limit": 35.2
-    }
+    },
+    "duration": [
+        "3.94",
+        "5.25",
+        "3.94"
+    ]
 }

--- a/dpa_check/tests/answers/JUL3018A_viol.json
+++ b/dpa_check/tests/answers/JUL3018A_viol.json
@@ -16,7 +16,7 @@
     ],
     "run_start": "2018:205:00:42:38.816",
     "limits": {
-        "yellow_hi": 37.2,
-        "plan_limit_hi": 35.2
+        "yellow_hi_limit": 37.2,
+        "plan_hi_limit": 35.2
     }
 }

--- a/dpa_check/tests/dpa_test_spec.json
+++ b/dpa_check/tests/dpa_test_spec.json
@@ -170,7 +170,7 @@
                     0.7
                 ],
                 "eclipse_comp": "eclipse",
-                "epoch": "2018:003",
+                "epoch": "2018:003:12:00:00",
                 "pitch_comp": "pitch",
                 "simz_comp": "sim_z",
                 "var_func": "linear"


### PR DESCRIPTION
## Description

This PR implements changes to support tracking, plotting, and reporting of violations of the +12 degC limit when 0 FEPs are on. 

Minor updates to the regression tests are also required, to account for:

* The additions of violation durations to the violation test answers
* The changing of the limit variable names
* Adding explicit `12:00:00` to the epoch value in the test model specification to accommodate the switch to `cxotime`

The code changes here require https://github.com/acisops/acis_thermal_check/pull/37.


## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing
